### PR TITLE
smart_scraper_local.py:  Allow using a remote Ollama #53

### DIFF
--- a/examples/local/smart_scraper_local.py
+++ b/examples/local/smart_scraper_local.py
@@ -20,7 +20,8 @@ graph_config = {
         "model": "ollama/mistral",
         "temperature": 0,
         "format": "json",  # Ollama needs the format to be specified explicitly
-        # "model_tokens": 2000, # set context length arbitrarily
+        # "model_tokens": 2000, # set context length arbitrarily,
+        # "base_url": "http://ollama:11434", # set ollama URL arbitrarily
     },
 }
 


### PR DESCRIPTION
Since you pass `config["llm"]` to langchain ChatOllama(), it's only a matter of adding a new parameter `base_url`.