### PR TITLE
fix: limit python version to < 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = ">=3.9, <3.12"
 langchain = "0.1.15"
 langchain-openai = "^0.1.6"
 langchain-google-genai = "^1.0.3"


### PR DESCRIPTION
pkgutil.ImpImporter has been deprecated in python 3.12 and that makes poetry install crash for those on python 3.12.
Limited the range of accepted python versions for now.
I think the error happens specifically while building yahoo-search-py which I see onw of you authored so maybe you can have a look there later.
Fixes #189 