### PR TITLE
Fetch links in the page while parsing html

### DIFF
--- a/scrapegraphai/utils/__init__.py
+++ b/scrapegraphai/utils/__init__.py
@@ -6,4 +6,4 @@ from .convert_to_csv import convert_to_csv
 from .convert_to_json import convert_to_json
 from .prettify_exec_info import prettify_exec_info
 from .proxy_rotation import proxy_generator
-from .remover import remover
+from .cleanup_html import cleanup_html

--- a/scrapegraphai/utils/cleanup_html.py
+++ b/scrapegraphai/utils/cleanup_html.py
@@ -3,9 +3,9 @@ Module for minimizing the code
 """
 from bs4 import BeautifulSoup
 from minify_html import minify
+from urllib.parse import urljoin
 
-
-def remover(html_content: str) -> str:
+def cleanup_html(html_content: str, base_url: str) -> str:
     """
     Processes HTML content by removing unnecessary tags, minifying the HTML, and extracting the title and body content.
 
@@ -33,11 +33,21 @@ def remover(html_content: str) -> str:
     for tag in soup.find_all(['script', 'style']):
         tag.extract()
 
+    # Links extraction
+    links = soup.find_all('a')
+    link_urls = []
+    for link in links:
+        if 'href' in link.attrs:
+            link_urls.append(urljoin(base_url, link['href']))
+
     # Body Extraction (if it exists)
     body_content = soup.find('body')
     if body_content:
         # Minify the HTML within the body tag
         minimized_body = minify(str(body_content))
-        return "Title: " + title + ", Body: " + minimized_body
+        print("Came here")
+        return "Title: " + title + ", Body: " + minimized_body + ", Links: " + str(link_urls)
 
-    return "Title: " + title + ", Body: No body content found"
+
+    print("No Came here")
+    return "Title: " + title + ", Body: No body content found" + ", Links: " + str(link_urls)


### PR DESCRIPTION
Commit https://github.com/VinciGit00/Scrapegraph-ai/commit/f8ce3d5916eab926275d59d4d48b0d89ec9cd43f was reverted.

- While changing the target, looks like one of the import was missed. That is now fixed
- For the links within the baseurl, only absolute links were getting retrieved. Now added urlJoin to fetch complete navigable urls: /projects/rotary-pendulum-rl/ -> https://perinim.github.io/projects/rotary-pendulum-rl/
- Moved the logic to fetch urls to the utils