### PR TITLE
feat: Custom AWS credentials

### DIFF
--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -190,12 +190,13 @@ class AbstractGraph(ABC):
         elif "bedrock" in llm_params["model"]:
             llm_params["model"] = llm_params["model"].split("/")[-1]
             model_id = llm_params["model"]
-
+            client = llm_params.get('client', None)
             try:
                 self.model_token = models_tokens["bedrock"][llm_params["model"]]
             except KeyError as exc:
                 raise KeyError("Model not supported") from exc
             return Bedrock({
+                "client": client,
                 "model_id": model_id,
                 "model_kwargs": {
                     "temperature": llm_params["temperature"],
@@ -289,11 +290,12 @@ class AbstractGraph(ABC):
             return GoogleGenerativeAIEmbeddings(model=embedder_config["model"])
         elif "bedrock" in embedder_config["model"]:
             embedder_config["model"] = embedder_config["model"].split("/")[-1]
+            client = embedder_config.get('client', None)
             try:
                 models_tokens["bedrock"][embedder_config["model"]]
             except KeyError as exc:
                 raise KeyError("Model not supported") from exc
-            return BedrockEmbeddings(client=None, model_id=embedder_config["model"])
+            return BedrockEmbeddings(client=client, model_id=embedder_config["model"])
         else:
             raise ValueError(
                 "Model provided by the configuration not supported")

--- a/scrapegraphai/models/anthropic.py
+++ b/scrapegraphai/models/anthropic.py
@@ -1,0 +1,17 @@
+""" 
+Anthropic Module
+"""
+from langchain_anthropic import ChatAnthropic
+
+
+class Anthropic(ChatAnthropic):
+    """
+    A wrapper for the ChatAnthropic class that provides default configuration
+    and could be extended with additional methods if needed.
+
+    Args:
+        llm_config (dict): Configuration parameters for the language model.
+    """
+
+    def __init__(self, llm_config: dict):
+        super().__init__(**llm_config)


### PR DESCRIPTION
This PR adds support for custom AWS credentials passed via graph configs.

**Example:**

```python
import boto3

from scrapegraphai.graphs import SmartScraperGraph

# 0a. Initialize session
session = boto3.Session(
    aws_access_key_id="...",
    aws_secret_access_key="...",
    aws_session_token="...",
    region_name="us-east-1"
)

# 0b. Initialize client
client = session.client("bedrock-runtime")

# 1. Define graph configuration
config = {
    "llm": {
        "client": client,
        "model": "bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
        "temperature": 0.0,
        "format": "json"
    },
    "embeddings": {
        "client": client,
        "model": "bedrock/cohere.embed-multilingual-v3",
    },
}

# 2. Create graph instance
graph = SmartScraperGraph(
    prompt="List me all the articles",
    source="https://perinim.github.io/projects",
    config=config
)

# 3. Scrape away!
print(graph.run())

# Ouput: {'articles': ['Rotary Pendulum RL', 'DQN Implementation from scratch', 'Multi Agents HAED', 'Wireless ESC for Modular Drones']}
```