### PR TITLE
fix: Add a new graph traversal that allows more than one edges out of a graph

### DIFF
--- a/scrapegraphai/nodes/conditional_node.py
+++ b/scrapegraphai/nodes/conditional_node.py
@@ -13,46 +13,33 @@ class ConditionalNode(BaseNode):
     This node type is used to implement branching logic within the graph, allowing 
     for dynamic paths based on the data available in the current state.
 
+    It is expected thar exactly two edges are created out of this node.
+    The first node is chosen for execution if the key exists and has a non-empty value,
+    and the second node is chosen if the key does not exist or is empty.
+
     Attributes:
         key_name (str): The name of the key in the state to check for its presence.
-        next_nodes (list): A list of two node instances. The first node is chosen 
-                           for execution if the key exists and has a non-empty value, 
-                           and the second node is chosen if the key does not exist or 
-                           is empty.
 
     Args:
         key_name (str): The name of the key to check in the graph's state. This is 
                         used to determine the path the graph's execution should take.
-        next_nodes (list): A list containing exactly two node instances, specifying 
-                           the next nodes to execute based on the condition's outcome.
         node_name (str, optional): The unique identifier name for the node. Defaults 
                                    to "ConditionalNode".
 
-    Raises:
-        ValueError: If next_nodes does not contain exactly two elements, indicating 
-                    a misconfiguration in specifying the conditional paths.
     """
 
-    def __init__(self, key_name: str, next_nodes: list, node_name="ConditionalNode"):
+    def __init__(self, key_name: str, node_name="ConditionalNode"):
         """
         Initializes the node with the key to check and the next node names based on the condition.
 
         Args:
             key_name (str): The name of the key to check in the state.
-            next_nodes (list): A list containing exactly two names of the next nodes.
-                               The first is used if the key exists, the second if it does not.
-
-        Raises:
-            ValueError: If next_nodes does not contain exactly two elements.
         """
 
         super().__init__(node_name, "conditional_node")
         self.key_name = key_name
-        if len(next_nodes) != 2:
-            raise ValueError("next_nodes must contain exactly two elements.")
-        self.next_nodes = next_nodes
 
-    def execute(self, state: dict) -> str:
+    def execute(self, state: dict) -> dict:
         """
         Checks if the specified key is present in the state and decides the next node accordingly.
 
@@ -64,5 +51,7 @@ class ConditionalNode(BaseNode):
         """
 
         if self.key_name in state and len(state[self.key_name]) > 0:
-            return self.next_nodes[0].node_name
-        return self.next_nodes[1].node_name
+            state["next_node"] = 0
+        else:
+            state["next_node"] = 1
+        return state


### PR DESCRIPTION
The current graph traversal is very sub-optimal and confusing. We were iterating throught all the nodes and then looking for the edges out of this. Also, it was constrained that one node could be connected to another node

For usecases such as n-level deep search, there would be a requirement to add more than child nodes out of the node. For example, pipeline for n-level deep search would look like:
<img width="1085" alt="Screenshot 2024-05-15 at 1 53 42 PM" src="https://github.com/VinciGit00/Scrapegraph-ai/assets/12783454/bcf7ab18-b1ab-46b7-ba88-3dc4924ecc09">
