### PR TITLE
bugfix: ScriptCreatorGraph verbose settings + RobotsNode handling model IDs

### DIFF
--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -49,6 +49,11 @@ class AbstractGraph(ABC):
         self.embedder_model = self._create_default_embedder(llm_config=config["llm"]
                                                             ) if "embeddings" not in config else self._create_embedder(
             config["embeddings"])
+        self.verbose = False if config is None else config.get(
+            "verbose", False)
+        self.headless = True if config is None else config.get(
+            "headless", True)
+        self.loader_kwargs = config.get("loader_kwargs", {})
 
         # Create the graph
         self.graph = self._create_graph()
@@ -56,12 +61,6 @@ class AbstractGraph(ABC):
         self.execution_info = None
 
         # Set common configuration parameters
-        self.verbose = False if config is None else config.get(
-            "verbose", False)
-        self.headless = True if config is None else config.get(
-            "headless", True)
-        self.loader_kwargs = config.get("loader_kwargs", {})
-
         common_params = {"headless": self.headless,
                          "verbose": self.verbose,
                          "loader_kwargs": self.loader_kwargs,

--- a/scrapegraphai/nodes/robots_node.py
+++ b/scrapegraphai/nodes/robots_node.py
@@ -100,8 +100,7 @@ class RobotsNode(BaseNode):
                 self.llm_model.model_name = self.llm_model.model_name.split("/")[-1]
                 model = self.llm_model.model_name.split("/")[-1]
             elif hasattr(self.llm_model, "model_id"):  # Bedrock uses model IDs, not model names
-                self.llm_model.model_name = self.llm_model.model_id.split("/")[-1]
-                model = self.llm_model.model_name
+                model = self.llm_model.model_id.split("/")[-1]
             else:
                 model = self.llm_model.model_name
             try:

--- a/scrapegraphai/nodes/robots_node.py
+++ b/scrapegraphai/nodes/robots_node.py
@@ -96,10 +96,12 @@ class RobotsNode(BaseNode):
             base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
             loader = AsyncChromiumLoader(f"{base_url}/robots.txt")
             document = loader.load()
-            if "ollama" in self.llm_model.model_name:
+            if hasattr(self.llm_model, "model_name") and "ollama" in self.llm_model.model_name:
                 self.llm_model.model_name = self.llm_model.model_name.split("/")[-1]
                 model = self.llm_model.model_name.split("/")[-1]
-
+            elif hasattr(self.llm_model, "model_id"):  # Bedrock uses model IDs, not model names
+                self.llm_model.model_name = self.llm_model.model_id.split("/")[-1]
+                model = self.llm_model.model_name
             else:
                 model = self.llm_model.model_name
             try:


### PR DESCRIPTION
This PR fixes bugs found while testing https://github.com/VinciGit00/Scrapegraph-ai/pull/272

## `ScriptGraphCreator`: Missing `verbose` attribute

The `ScriptCreatorGraph` class tries to access the `verbose` attribute

https://github.com/VinciGit00/Scrapegraph-ai/blob/f1a25233d650010e1932e0ab80938079a22a296d/scrapegraphai/graphs/script_creator_graph.py#L68

before it is set 

https://github.com/VinciGit00/Scrapegraph-ai/blob/f1a25233d650010e1932e0ab80938079a22a296d/scrapegraphai/graphs/abstract_graph.py#L59

**Example:**

```bash
python examples/bedrock/script_generator_bedrock.py
```

**Before:**

```
AttributeError: 'ScriptCreatorGraph' object has no attribute 'verbose'
```

**After:**

```
source: https://perinim.github.io/projects
from bs4 import BeautifulSoup

import requests

url = "https://perinim.github.io/projects"
response = requests.get(url)
soup = BeautifulSoup(response.content, "html.parser")

projects = soup.find_all("div", class_="card hoverable")

for project in projects:
    title = project.find("h4", class_="card-title").text
    description = project.find("p", class_="card-text").text
    print(f"Title: {title}")
    print(f"Description: {description}")
    print()
         node_name  total_tokens  prompt_tokens  ...  successful_requests  total_cost_USD  exec_time
0            Fetch             0              0  ...                    0             0.0   8.533663
1            Parse             0              0  ...                    0             0.0   0.318253
2  GenerateScraper             0              0  ...                    1             0.0   3.118265
3     TOTAL RESULT             0              0  ...                    1             0.0  11.970181

[4 rows x 7 columns]
```

## `RobotsNode`: Missing `model_name`

Amazon Bedrock uses model IDs, not model names.

https://github.com/VinciGit00/Scrapegraph-ai/blob/9e92b03913245c32b6cec0ea7fb41d82a759d0c3/scrapegraphai/nodes/robots_node.py#L99-L104

**Example:**

```bash
python examples/bedrock/custom_graph_bedrock.py
```

**Before:**

```
AttributeError: 'Bedrock' object has no attribute 'model_name'
```

**After:**

```
--- Executing Robots Node ---
(Scraping this website is allowed)
--- Executing Fetch Node ---
--- Executing Parse Node ---
--- Executing RAG Node ---
--- (updated chunks metadata) ---
--- (tokens compressed and vector stored) ---
--- Executing GenerateAnswer Node ---
Processing chunks: 100%|█████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 3971.88it/s]
{
    "articles": [
        "Rotary Pendulum RL",
        "DQN Implementation from scratch",
        "Multi Agents HAED",
        "Wireless ESC for Modular Drones"
    ]
}
```

