### PR TITLE
fix(deepcopy): TypeError related to pickling '_thread.RLock' objects

### DIFF
--- a/scrapegraphai/graphs/smart_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/smart_scraper_multi_graph.py
@@ -2,7 +2,6 @@
 SmartScraperMultiGraph Module
 """
 
-from copy import copy, deepcopy
 from typing import List, Optional
 
 from .base_graph import BaseGraph
@@ -46,10 +45,21 @@ class SmartScraperMultiGraph(AbstractGraph):
 
         self.max_results = config.get("max_results", 3)
 
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
+        # Custom deepcopy function to handle non-picklable objects
+        def custom_deepcopy(obj):
+            if isinstance(obj, dict):
+                return {k: custom_deepcopy(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [custom_deepcopy(v) for v in obj]
+            elif hasattr(obj, '__dict__'):
+                new_obj = obj.__class__()
+                for attr in obj.__dict__:
+                    setattr(new_obj, attr, custom_deepcopy(getattr(obj, attr)))
+                return new_obj
+            else:
+                return obj
+
+        self.copy_config = custom_deepcopy(config)
 
         super().__init__(prompt, config, source, schema)
 


### PR DESCRIPTION
Related to #374

Implements a custom deep copy function in `SmartScraperMultiGraph` to handle non-picklable objects and prevent `TypeError` during object copying.

- **Custom Deep Copy Function**: Introduces a custom deep copy function within the `__init__` method of `SmartScraperMultiGraph`. This function is designed to safely copy configurations, including handling of non-picklable objects like `_thread.RLock`, which resolves the issue of `TypeError` when attempting to pickle such objects.
- **Configuration Copying**: Utilizes the custom deep copy function to copy the `config` dictionary passed to `SmartScraperMultiGraph`. This ensures that the configurations for `AzureChatOpenAI` and `AzureOpenAIEmbeddings` instances are copied without raising exceptions related to pickling.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/VinciGit00/Scrapegraph-ai/issues/374?shareId=5bdc9608-819e-4323-b6bd-7927752dd583).