### PR TITLE
Strip out the scheme from the proxy server address URI.

### DIFF
--- a/scrapegraphai/utils/proxy_rotation.py
+++ b/scrapegraphai/utils/proxy_rotation.py
@@ -4,6 +4,7 @@ Module for rotating proxies
 
 import ipaddress
 import random
+import re
 from typing import List, Optional, Set, TypedDict
 
 import requests
@@ -230,7 +231,7 @@ def parse_or_search_proxy(proxy: Proxy) -> ProxySettings:
     """
     assert "server" in proxy, "missing server in the proxy configuration"
 
-    server_address = proxy["server"].split(":", maxsplit=1)[0]
+    server_address = re.sub(r'^\w+://', '', proxy["server"]).split(":", maxsplit=1)[0]
 
     if is_ipv4_address(server_address):
         return _parse_proxy(proxy)


### PR DESCRIPTION
As stated in the proxy documentation part [here](https://scrapegraph-ai.readthedocs.io/en/latest/scrapers/graph_config.html#proxy-rotation), this example shows proxy server address set to `http://your_proxy_server:port`, which throws an error since the IPv4 check is made with the URL scheme included such as `http://your_proxy_server`, thus causing the condition to skip and resulting in an `AssertionError`.

This pull request strips out any URL scheme found in the proxy server address, matching with the example provided within the documentation.