### PR TITLE
Fix a small typo in the warning message

### DIFF
--- a/scrapegraphai/graphs/base_graph.py
+++ b/scrapegraphai/graphs/base_graph.py
@@ -55,7 +55,7 @@ class BaseGraph:
         if nodes[0].node_name != entry_point.node_name:
             # raise a warning if the entry point is not the first node in the list
             warnings.warn(
-                "Careful! The entry point node is different from the first node if the graph.")
+                "Careful! The entry point node is different from the first node in the graph.")
         
         # Burr configuration
         self.use_burr = use_burr


### PR DESCRIPTION
This PR fixes a small typo in the warning message.

Thank you for this great library.